### PR TITLE
Getting tip-spec to work with the newest quickSpec

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ extra-deps:
 - testing-feat-0.4.0.3
 - tagshare-0.0
 - git: git://github.com/nick8325/quickspec
-  commit: c89663028e0a6cccaba91e0ba8e2788d95d43e9b
+  commit: de940cabec26b0a22a2f97dcd71d90383224e1fd
 flags:
     tip-spec: {stack: True}
     tip-ghc: {stack: True}

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - jukebox-0.2.17
 - minisat-0.1.2
 - structural-induction-0.3
-- twee-lib-2.1.3
+- twee-lib-2.1.4
 - genifunctors-0.4
 - stm-promise-0.0.3.1
 - constraints-0.9.1
@@ -19,8 +19,7 @@ extra-deps:
 - testing-feat-0.4.0.3
 - tagshare-0.0
 - git: git://github.com/nick8325/quickspec
-  commit: d60a7de8adb32aa8d1be42c0c2af28cdbe96f9ac
-
+  commit: c89663028e0a6cccaba91e0ba8e2788d95d43e9b
 flags:
     tip-spec: {stack: True}
     tip-ghc: {stack: True}

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ extra-deps:
 - testing-feat-0.4.0.3
 - tagshare-0.0
 - git: git://github.com/nick8325/quickspec
-  commit: de940cabec26b0a22a2f97dcd71d90383224e1fd
+  commit: 4bf44700b2f582727f871022ea8aa8ba30c6f7cb
 flags:
     tip-spec: {stack: True}
     tip-ghc: {stack: True}

--- a/tip-lib/src/Tip/Haskell/Translate.hs
+++ b/tip-lib/src/Tip/Haskell/Translate.hs
@@ -742,11 +742,7 @@ makeSig qspms@QuickSpecParams{..} thy@Theory{..} =
       map constant_decl (ctor_constants ++ builtin_constants)
     ]
   ]
-  --FIXME: What does this do?
-  -- ++ map instance_decl (ctor_constants ++ builtin_constants ++ func_constants)
   ++
-  --FIXME: What does this do?
-  -- [ Apply (quickSpec "inst") [Apply (prelude "undefined") [] ::: H.TyCon (ratio "Rational") []] ] ++
   [ mk_inst [] (mk_class (feat "Enumerable") (H.TyCon (prelude "Int") [])) ] ++
   [ mk_inst [] (mk_class (typeable "Typeable") (H.TyCon (prelude "Int") [])) ] ++
   [ mk_inst [] (mk_class (quickCheck "CoArbitrary") (H.TyCon (prelude "Int") [])) ] ++
@@ -762,7 +758,8 @@ makeSig qspms@QuickSpecParams{..} thy@Theory{..} =
                 (typeable "Typeable", typeable "Typeable")]
   , let tys = map trType (qsTvs n)
   ] ++
-  [ mk_inst (map (mk_class (feat "Enumerable")) tys) (mk_class (quickCheck "Arbitrary") (H.TyCon t tys))
+  [ mk_inst (map (mk_class (feat "Enumerable")) tys)
+    (mk_class (quickCheck "Arbitrary") (H.TyCon t tys))
   | (t,n) <- type_univ, t `notElem` (map (\(a,b,c) -> a) obsTriples)
   , let tys = map trType (qsTvs n)
   ] ++

--- a/tip-lib/src/Tip/Haskell/Translate.hs
+++ b/tip-lib/src/Tip/Haskell/Translate.hs
@@ -781,8 +781,9 @@ makeSig qspms@QuickSpecParams{..} thy@Theory{..} =
   [ Apply (quickSpec "inst") [H.Lam [TupPat []] (Apply (Derived f "gen") [])]
   | Signature f _ _ <- thy_sigs
   ] ++
-  [Apply (quickSpec "withMaxTermSize") [H.Int 7]] --TODO: Is 7 the best choice?
-  --TODO: Maybe set more parameters?
+  [Apply (quickSpec "withMaxTermSize") [H.Int 7]]
+  --TODO: Is 7 the best choice? Make size tweakable?
+  --TODO: Set more parameters?
   where
     imps = ufInfo thy
 

--- a/tip-lib/src/Tip/Haskell/Translate.hs
+++ b/tip-lib/src/Tip/Haskell/Translate.hs
@@ -746,7 +746,7 @@ makeSig qspms@QuickSpecParams{..} thy@Theory{..} =
           --, --(quickSpec "instances",
              --Apply (prelude "mconcat") [List $
                  --FIXME: type errors happening here!
-                 -- ++ map instance_decl (ctor_constants ++ builtin_constants ++ func_constants)
+                 ++ map instance_decl (ctor_constants ++ builtin_constants ++ func_constants)
                  ++
                  --FIXME: What does this do?
               -- [ Apply (quickSpec "inst") [Apply (prelude "undefined") [] ::: H.TyCon (ratio "Rational") []] ] ++
@@ -813,7 +813,7 @@ makeSig qspms@QuickSpecParams{..} thy@Theory{..} =
         lam = H.Lam [H.ConPat (constraints "Dict") []]
 
     instance_decl (_,t) =
-      Apply (quickSpec "inst") [H.Lam [foldr pairPat (H.TupPat []) args] res ::: ty]
+      Apply (quickSpec "instFun") [H.Lam [foldr pairPat (H.TupPat []) args] res ::: ty]
       where
         (pre, _) = qsType t
         args = replicate (length pre) (H.ConPat (constraints "Dict") [])

--- a/tip-spec/src/Tip/QuickSpec.hs
+++ b/tip-spec/src/Tip/QuickSpec.hs
@@ -28,7 +28,6 @@ theorySignature params thy =
       do let a_file = dir </> "A" <.> "hs"
          let (thy_doc, rename_map) = ppTheoryWithRenamings "A" (QuickSpec params) thy
          writeFile a_file (show thy_doc)
-         -- print thy_doc
          setCurrentDirectory dir
          r <- runInterpreter $
            do unsafeSetGhcOption "-hide-package QuickCheck"
@@ -50,11 +49,10 @@ theorySignature params thy =
 exploreTheory :: Name a => QuickSpecParams -> Theory a -> IO (Theory a)
 exploreTheory params thy =
   do (sig,rm) <- theorySignature params thy
-     sig' <- toStderr (quickSpec $ [withPruningDepth 0] ++ sig)
+     sig' <- toStderr (quickSpecResult $ [withPruningDepth 0] ++ sig)
      let bm  = backMap thy rm
-     --let fms = mapM (trProperty bm) (filter shouldPrint (nub (QS.background sig'))) `freshFrom` thy
-     --return thy { thy_asserts = thy_asserts thy ++ fms }
-     return thy
+     let fms = mapM (trProperty bm) sig' `freshFrom` thy
+     return thy { thy_asserts = thy_asserts thy ++ fms }
 
 toStderr :: IO a -> IO a
 toStderr mx = do
@@ -64,4 +62,3 @@ toStderr mx = do
   hDuplicateTo oldStdout stdout
   hClose oldStdout
   return x
-

--- a/tip-spec/src/Tip/QuickSpec.hs
+++ b/tip-spec/src/Tip/QuickSpec.hs
@@ -28,6 +28,7 @@ theorySignature params thy =
       do let a_file = dir </> "A" <.> "hs"
          let (thy_doc, rename_map) = ppTheoryWithRenamings "A" (QuickSpec params) thy
          writeFile a_file (show thy_doc)
+         print thy_doc
          setCurrentDirectory dir
          r <- runInterpreter $
            do unsafeSetGhcOption "-hide-package QuickCheck"

--- a/tip-spec/src/Tip/QuickSpec.hs
+++ b/tip-spec/src/Tip/QuickSpec.hs
@@ -28,11 +28,11 @@ theorySignature params thy =
       do let a_file = dir </> "A" <.> "hs"
          let (thy_doc, rename_map) = ppTheoryWithRenamings "A" (QuickSpec params) thy
          writeFile a_file (show thy_doc)
-         print thy_doc
+         -- print thy_doc
          setCurrentDirectory dir
          r <- runInterpreter $
            do unsafeSetGhcOption "-hide-package QuickCheck"
-              unsafeSetGhcOption "-package QuickCheck-2.10.1" --FIXME: is this the right QC version?
+              unsafeSetGhcOption "-package QuickCheck-2.10.1"
               loadModules ["A"]
               setImports ["A","QuickSpec","QuickSpec.Term","Prelude"]
               sig <- interpret "sig" (undefined :: [Sig])


### PR DESCRIPTION
tip-spec now works with the newest version of quickSpec (and can be used by Hipster).