### PR TITLE
Fix definition of minus

### DIFF
--- a/tip-lib/src/Tip/Pass/Concretise.hs
+++ b/tip-lib/src/Tip/Pass/Concretise.hs
@@ -53,7 +53,7 @@ Right nat_theory =
          "((succ x)",
            "(match y",
              "(((succ y) (minus x y))",
-               "(zero zero)))))))",
+               "(zero (succ x))))))))",
     "(define-fun-rec times :definition :source |*|",
       "((x Nat) (y Nat)) Nat",
       "(match x",


### PR DESCRIPTION
The current definition of `minus` satisfies `minus x y = zero` for all `x` and `y`.